### PR TITLE
Fix Feb 2026 Hytale server compatibility

### DIFF
--- a/src/main/java/com/electro/hycitizens/managers/CitizensManager.java
+++ b/src/main/java/com/electro/hycitizens/managers/CitizensManager.java
@@ -1664,9 +1664,7 @@ public class CitizensManager {
             transform.bodyOrientation = bodyDirection;
 
             // Create ComponentUpdate
-            ComponentUpdate update = new ComponentUpdate();
-            update.type = ComponentUpdateType.Transform;
-            update.transform = transform;
+            TransformUpdate update = new TransformUpdate(transform);
 
             // Create EntityUpdate
             EntityUpdate entityUpdate = new EntityUpdate(


### PR DESCRIPTION
## Summary

Fixes two issues caused by the February 2026 Hytale server update:

- **InstantiationError on ComponentUpdate**: `ComponentUpdate` is now abstract. Replaced direct instantiation with `TransformUpdate` subclass in `rotateCitizenToPlayer`.
- **NPC skins stripped on spawn**: `writeRoleFile` was unconditionally rewriting role JSON files, triggering Hytale hot-reload which reset NPC appearance. Now skips the write when file content is unchanged.

## Changes

- `CitizensManager.java`: `new ComponentUpdate()` -> `new TransformUpdate(transform)`
- `RoleGenerator.java`: Compare existing file content before writing; skip if identical

## Testing

Tested on a live server with player-model NPCs with custom skins. NPCs rotate toward players without crashing and skins persist across spawns.