### PR TITLE
Fix async PlayerRef.getComponent error in revokeTemporaryPermissions

### DIFF
--- a/src/main/java/com/electro/hycitizens/util/CommandExecutionUtil.java
+++ b/src/main/java/com/electro/hycitizens/util/CommandExecutionUtil.java
@@ -5,6 +5,8 @@ import com.hypixel.hytale.server.core.command.system.CommandManager;
 import com.hypixel.hytale.server.core.console.ConsoleSender;
 import com.hypixel.hytale.server.core.permissions.PermissionsModule;
 import com.hypixel.hytale.server.core.universe.PlayerRef;
+import com.hypixel.hytale.server.core.universe.Universe;
+import com.hypixel.hytale.server.core.universe.world.World;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -130,8 +132,14 @@ public final class CommandExecutionUtil {
             return CompletableFuture.completedFuture(null);
         }
 
-        execution.whenComplete((ignored, throwable) ->
-                revokeTemporaryPermissions(permissionsModule, playerUuid, missingPermissions));
+        execution.whenComplete((ignored, throwable) -> {
+            World world = Universe.get() != null ? Universe.get().getWorld(player.getWorldUuid()) : null;
+            if (world != null) {
+                world.execute(() -> revokeTemporaryPermissions(permissionsModule, playerUuid, missingPermissions));
+            } else {
+                revokeTemporaryPermissions(permissionsModule, playerUuid, missingPermissions);
+            }
+        });
 
         return execution;
     }


### PR DESCRIPTION
The whenComplete callback on the command execution future was firing on the ForkJoinPool async thread. Calling PermissionsModule.removeUserPermission there fired a sync event, causing WorldMapTracker to access PlayerRef components off the main tick thread. Dispatch the revoke via world.execute() to run it on the correct world thread.